### PR TITLE
the function name is different during runtime than in aws console

### DIFF
--- a/lambdas/helpers/dynamoDBHelper.js
+++ b/lambdas/helpers/dynamoDBHelper.js
@@ -39,7 +39,7 @@ const getSiteConfig = async (params) => {
     });
 };
 
-const functionNameRE = /^us-east-1:federalist-proxy-(prod|staging|test)-(viewer|origin)-(request|response):\d+$/;
+const functionNameRE = /^us-east-1.federalist-proxy-(prod|staging|test)-(viewer|origin)-(request|response)$/;
 
 const getAppConfig = (functionName) => {
   const match = functionNameRE.exec(functionName);

--- a/test/helpers/dynamoDBHelper.test.js
+++ b/test/helpers/dynamoDBHelper.test.js
@@ -116,7 +116,7 @@ describe('functionNameRE', () => {
     let functionName;
     for (i = 0; i < appEnvs.length; i += 1) {
       for (j = 0; j < eventTypes.length; j += 1) {
-        functionName = `us-east-1:federalist-proxy-${appEnvs[i]}-${eventTypes[j]}:${i * j * 10}`;
+        functionName = `us-east-1.federalist-proxy-${appEnvs[i]}-${eventTypes[j]}`;
         match = functionNameRE.exec(functionName);
         expect(match).to.be.an('array');
       }
@@ -124,31 +124,19 @@ describe('functionNameRE', () => {
   });
 
   it('fails for non test, staging and prod envs', () => {
-    const functionName = 'us-east-1:federalist-proxy-dev-viewer-request:0';
+    const functionName = 'us-east-1.federalist-proxy-dev-viewer-request';
     const match = functionNameRE.exec(functionName);
     expect(match).to.be.null;
   });
 
   it('fails for non-viwer/origin request', () => {
-    const functionName = 'us-east-1:federalist-proxy-test-blah-request:0';
+    const functionName = 'us-east-1.federalist-proxy-test-blah-request';
     const match = functionNameRE.exec(functionName);
     expect(match).to.be.null;
   });
 
   it('fails for non request/response events', () => {
-    const functionName = 'us-east-1:federalist-proxy-test-viewer-blah:0';
-    const match = functionNameRE.exec(functionName);
-    expect(match).to.be.null;
-  });
-
-  it('fails - requires numerical function', () => {
-    const functionName = 'us-east-1:federalist-proxy-test-viewer-request:b';
-    const match = functionNameRE.exec(functionName);
-    expect(match).to.be.null;
-  });
-
-  it('fails - requires versioned function', () => {
-    const functionName = 'us-east-1:federalist-proxy-test-viewer-request:';
+    const functionName = 'us-east-1.federalist-proxy-test-viewer-blah';
     const match = functionNameRE.exec(functionName);
     expect(match).to.be.null;
   });

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -61,7 +61,7 @@ const getResponseEvent = () => ({
   ],
 });
 
-const getContext = eventType => ({ functionName: `us-east-1:federalist-proxy-test-${eventType}:0` });
+const getContext = eventType => ({ functionName: `us-east-1.federalist-proxy-test-${eventType}` });
 
 module.exports = {
   stubDocDBQuery, getContext, getRequestEvent, getResponseEvent,


### PR DESCRIPTION
update functionName as exists in runtime:
- no version
- the region and handler name is delimited with a period instead of a semi-colon